### PR TITLE
WIP: Compile with cairo (but without java and pango)

### DIFF
--- a/R/plan.sh
+++ b/R/plan.sh
@@ -7,38 +7,46 @@ pkg_source="https://cran.r-project.org/src/base/R-3/${pkg_name}-${pkg_version}.t
 pkg_shasum="288e9ed42457c47720780433b3d5c3c20983048b789291cc6a7baa11f9428b91"
 pkg_upstream_url="https://www.r-project.org"
 pkg_description="R is a free software environment for statistical computing and graphics."
-pkg__deps=(
+pkg_build_deps=(
   core/coreutils
   core/texinfo
-)
-pkg_build_deps=(
-  core/bzip2
-  core/cairo
-  core/curl
   core/diffutils
   core/file
   core/gcc
+  core/make
+  core/pkg-config
+)
+
+pkg_deps=(
+  core/bzip2
+  core/cairo
+  core/curl
   core/icu
   core/libjpeg-turbo
   core/libpng
   core/libtiff
-  core/make
-  core/pango
   core/pcre
   core/perl
-  core/pkg-config
   core/readline
   core/xz
   core/zlib
+  core/gcc-libs
+  core/glib
+  core/expat
+  core/pixman
+  core/fontconfig
+  core/freetype
 )
 pkg_bin_dirs=(lib64/R/bin)
 pkg_include_dirs=(lib64/R/include)
 pkg_lib_dirs=(lib64/R/lib)
 
 do_build() {
+    sed -i '/#include.*<cairo-xlib.h>/d' ./configure
     ./configure --prefix="${pkg_prefix}" \
 		--with-x=no \
-	        --enable-memory-profiling > result.txt
+                --disable-java \
+	        --enable-memory-profiling
     make
 }
 


### PR DESCRIPTION
This commit:

- Moves some items from pkg_build_deps to pkg_deps.

- Add transitive dependencies into pkg_deps since it appears that only
  direct pkg_deps are added to the PKG_CONFIG_PATH. This probably
  makes sense since we might end up linking against them.

- Edits the configure file to ensure that the cairo test doesn't
  require.

- Disables java since it was failing post-configure-file edit, cause
  unknown.

- Removes pango since the pango+cairo test will require a slightly
  different edit.

The end result is an R binary which can output PNGs. However, there
are still a number of TODOs:

- [ ] Sort out the remained of pkg_deps vs pkg_build_deps. Namely, we
  should run `ldd` on the final compiled artifacts and make sure there
  are no unresolved libraries.

- [ ] Figure out how to turn java back on or decide that we are OK
  with it it disabled.

- [ ] Change my `sed` command so that it also works for the pango
  configure test.

- [ ] Figure out how we can make `cairo` the default type for
  functions like png().

Signed-off-by: Steven Danna <steve@chef.io>